### PR TITLE
Fix daemon manifest and fmt cleanup

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -12,7 +12,6 @@ tracing-subscriber = "0.3"
 signal-hook = { version = "0.3", features = ["iterator"] }
 crossbeam = "0.8"
 notify = "6"
-api = { path = "../api" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/daemon/bin/tinkerbell.rs
+++ b/crates/daemon/bin/tinkerbell.rs
@@ -1,9 +1,5 @@
 use daemon::config::Config;
 
-use std::sync::Arc;
-use tokio::sync::Notify;
-use api::start_api_server;
-
 fn main() -> anyhow::Result<()> {
     // Initialize logging
     tracing_subscriber::fmt::init();
@@ -13,13 +9,5 @@ fn main() -> anyhow::Result<()> {
     let cfg = Config::load(&path)?;
 
     // Start daemon
-    let notify = Arc::new(Notify::new());
-    let rt = tokio::runtime::Runtime::new()?;
-    let api_handle = rt.enter(|| start_api_server("127.0.0.1:50051".parse().unwrap(), notify.clone()));
-
-    let res = daemon::run(cfg);
-
-    notify.notify_waiters();
-    rt.block_on(api_handle)??;
-    res
+    daemon::run(cfg)
 }


### PR DESCRIPTION
## Summary
- remove nonexistent `api` dependency from daemon manifest
- drop API server runtime from daemon binary
- format and lint workspace

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `just test` *(fails: syscall_yield_order)*

------
https://chatgpt.com/codex/tasks/task_e_686ede0ce780832f86b3003ea45ad6e3