### PR TITLE
Replace compile tests with functional tests

### DIFF
--- a/crates/docsbookgen/src/lib.rs
+++ b/crates/docsbookgen/src/lib.rs
@@ -1,0 +1,16 @@
+//! Internal utilities for the docsbookgen binary.
+
+/// The name of the docs generation tool used for testing.
+pub const TOOL_NAME: &str = "docsbookgen";
+
+/// Returns the tool name.
+///
+/// # Examples
+///
+/// ```
+/// use docsbookgen::tool_name;
+/// assert_eq!("docsbookgen", tool_name());
+/// ```
+pub fn tool_name() -> &'static str {
+    TOOL_NAME
+}

--- a/crates/docsbookgen/tests/compile.rs
+++ b/crates/docsbookgen/tests/compile.rs
@@ -1,2 +1,0 @@
-#[test]
-fn compile() {}

--- a/crates/docsbookgen/tests/tool_name.rs
+++ b/crates/docsbookgen/tests/tool_name.rs
@@ -1,0 +1,6 @@
+use docsbookgen::tool_name;
+
+#[test]
+fn tool_name_returns_expected_value() {
+    assert_eq!("docsbookgen", tool_name());
+}

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,4 +1,16 @@
 //! Metrics library module placeholder.
 
+/// Returns the placeholder string for testing.
+///
+/// # Examples
+///
+/// ```
+/// use metrics::get_placeholder;
+/// assert_eq!("metrics", get_placeholder());
+/// ```
+pub fn get_placeholder() -> &'static str {
+    PLACEHOLDER
+}
+
 /// Placeholder public constant used for compile tests.
 pub const PLACEHOLDER: &str = "metrics";

--- a/crates/metrics/tests/compile.rs
+++ b/crates/metrics/tests/compile.rs
@@ -1,6 +1,0 @@
-use metrics::PLACEHOLDER;
-
-#[test]
-fn compile() {
-    assert_eq!("metrics", PLACEHOLDER);
-}

--- a/crates/metrics/tests/placeholder.rs
+++ b/crates/metrics/tests/placeholder.rs
@@ -1,0 +1,6 @@
+use metrics::get_placeholder;
+
+#[test]
+fn placeholder_returns_expected_value() {
+    assert_eq!("metrics", get_placeholder());
+}

--- a/crates/wal/src/lib.rs
+++ b/crates/wal/src/lib.rs
@@ -2,3 +2,15 @@
 
 /// Placeholder public constant used for compile tests.
 pub const PLACEHOLDER: &str = "wal";
+
+/// Returns the placeholder string for testing.
+///
+/// # Examples
+///
+/// ```
+/// use wal::get_placeholder;
+/// assert_eq!("wal", get_placeholder());
+/// ```
+pub fn get_placeholder() -> &'static str {
+    PLACEHOLDER
+}

--- a/crates/wal/tests/compile.rs
+++ b/crates/wal/tests/compile.rs
@@ -1,6 +1,0 @@
-use wal::PLACEHOLDER;
-
-#[test]
-fn compile() {
-    assert_eq!("wal", PLACEHOLDER);
-}

--- a/crates/wal/tests/placeholder.rs
+++ b/crates/wal/tests/placeholder.rs
@@ -1,0 +1,6 @@
+use wal::get_placeholder;
+
+#[test]
+fn placeholder_returns_expected_value() {
+    assert_eq!("wal", get_placeholder());
+}


### PR DESCRIPTION
## Summary
- remove trivial compile tests
- add library helper functions for metrics, wal, and docsbookgen
- create simple functional tests for each crate

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686edff96964832f9ae30af3a68806e6