### PR TITLE
remove closing tagline from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,5 +303,3 @@ mayfly/
 MIT OR Apache 2.0
 
 ---
-
-**Built with intent by [Microscaler](https://github.com/microscaler).**


### PR DESCRIPTION
## Summary
- drop conversational line from the end of the README

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test` *(fails: syscall_yield_order)*

------
https://chatgpt.com/codex/tasks/task_e_686ee2a6b4d8832f8a926ed42df060a3