### PR TITLE
Update daemon task roadmap

### DIFF
--- a/tasks/daemon/tasks.md
+++ b/tasks/daemon/tasks.md
@@ -8,14 +8,48 @@ Build the binary entrypoint for the `tinkerbell` agent, responsible for:
 
 ## Tasks
 
+### Initial Setup
+
 - [ ] Create `bin/tinkerbell.rs` to:
     - Load config
     - Initialize logging and metrics
     - Call `daemon::run()`
+    - Set up tracing via `tracing_subscriber` honoring `RUST_LOG`
 
 - [ ] In `lib.rs`, implement `init()` and `run()`
-- [ ] Implement signal handling (SIGINT, SIGTERM)
 - [ ] Add placeholder config loader (`config.rs`) using `serde` + `toml`
 - [ ] Plan file-watcher support for hot-reload of config (inotify / fsevents)
-- [ ] Add integration test to spawn the daemon and shut it down gracefully
 - [ ] Replace placeholder daemon tests with a check that init and run return successfully
+
+### Scheduler Bootstrapping
+
+- [ ] Construct the scheduler with sane defaults
+- [ ] Drive it using `run_blocking()`
+
+### Graceful Shutdown
+
+- [ ] Register `signal_hook` handlers for `SIGINT` and `SIGTERM`
+- [ ] Emit PAL events for `ShutdownBegin` and `ShutdownComplete`
+- [ ] Call `scheduler.shutdown(timeout)` when a signal is received
+
+### System Tasks
+
+- [ ] Implement `looptask_wal_flush()` and spawn it with priority `0`
+- [ ] Implement `looptask_metrics()` and spawn it with priority `0`
+
+### Metrics and Health Endpoints
+
+- [ ] Serve Prometheus metrics at `/metrics`
+- [ ] Provide a basic health check at `/__health`
+
+### Optional Interfaces (Feature Flags)
+
+- [ ] `ipc` feature: accept jobs via Unix socket
+- [ ] `grpc` feature: accept jobs over gRPC
+- [ ] `a2a` feature: emit and receive A2A protocol messages
+
+### Future Extensions
+
+- [ ] CLI flags for concurrency, logging, and quantum
+- [ ] `--dump-state` flag to output the scheduler snapshot
+- [ ] Add integration test to spawn the daemon and shut it down gracefully


### PR DESCRIPTION
## Summary
- clarify daemon TODOs with scheduler bootstrap, shutdown logic, system tasks
- describe metrics/health endpoints and optional IPC/grpc/a2a features
- outline future CLI flags and state dump command

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_686ed6fb5ce4832fb265fb4fe8218a09