### PR TITLE
Implement scheduler loop control in daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "anyhow",
  "crossbeam",
  "notify",
+ "scheduler",
  "serde",
  "signal-hook",
  "tempfile",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,6 +13,7 @@ signal-hook = { version = "0.3", features = ["iterator"] }
 crossbeam = "0.8"
 notify = "6"
 tokio = { version = "1", features = ["rt", "sync"] }
+scheduler = { path = "../scheduler" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -3,6 +3,11 @@
 pub mod config;
 mod signal;
 
+use crossbeam::channel::{Receiver, RecvTimeoutError};
+use scheduler::Scheduler;
+use std::time::Duration;
+use tracing::instrument;
+
 use config::Config;
 use signal::shutdown_channel;
 
@@ -18,6 +23,26 @@ pub fn run(cfg: Config) -> anyhow::Result<()> {
     init(cfg)?.run()
 }
 
+/// Drive the scheduler until a shutdown signal is received.
+///
+/// This loops over [`Scheduler::run`] to process any queued tasks and waits for
+/// a notification on `shutdown` before returning. When the scheduler becomes
+/// idle it blocks on the receiver for a short interval so that the loop does
+/// not busy spin.
+#[instrument(skip(sched, shutdown))]
+fn run_blocking(sched: &mut Scheduler, shutdown: &Receiver<()>) {
+    loop {
+        sched.run();
+        if shutdown.try_recv().is_ok() {
+            break;
+        }
+        match shutdown.recv_timeout(Duration::from_millis(50)) {
+            Ok(_) | Err(RecvTimeoutError::Disconnected) => break,
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
 /// Daemon state returned from [`init`].
 pub struct Daemon {
     cfg: Config,
@@ -25,13 +50,16 @@ pub struct Daemon {
 }
 
 impl Daemon {
-    /// Block until a shutdown signal is received.
+    /// Run the daemon until a termination signal is delivered.
+    #[instrument(skip(self))]
     pub fn run(self) -> anyhow::Result<()> {
         tracing::info!("daemon running");
         // Watch for config changes (stub).
         let _watcher = signal::start_watcher(&self.cfg.config_path).ok();
-        // Wait for shutdown signal.
-        let _ = self.shutdown.recv();
+
+        let mut sched = Scheduler::new();
+        run_blocking(&mut sched, &self.shutdown);
+
         tracing::info!("daemon shutdown complete");
         Ok(())
     }

--- a/crates/daemon/tests/daemon.rs
+++ b/crates/daemon/tests/daemon.rs
@@ -4,7 +4,7 @@ use signal_hook::low_level::raise;
 use std::time::Duration;
 
 #[test]
-fn init_and_run() {
+fn scheduler_exits_on_sigterm() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("config.toml");
     std::fs::write(&path, "").unwrap();


### PR DESCRIPTION
## Summary
- run the daemon's scheduler with a new `run_blocking` helper
- invoke that helper from `Daemon::run`
- depend on the `scheduler` crate
- test that SIGTERM stops the scheduler loop

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_686eeb0cd700832f945878419a96d336