### PR TITLE
Add daemon system looptasks and spawn API

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5,7 +5,7 @@ mod pal;
 mod signal;
 
 use crossbeam::channel::RecvTimeoutError;
-use scheduler::Scheduler;
+use scheduler::{Scheduler, SystemCall, TaskContext};
 use std::time::Duration;
 use tracing::instrument;
 
@@ -13,6 +13,34 @@ use config::Config;
 use signal::shutdown_channel;
 
 pub use pal::{DaemonEvent, emit as pal_emit, take_events};
+
+/// Loop task responsible for periodically flushing the write-ahead log.
+///
+/// This task demonstrates a simple system coroutine that would normally
+/// interact with the `wal` crate. It records start and finish events in the
+/// process activity log and sleeps briefly to simulate work.
+#[instrument(skip(ctx))]
+pub fn looptask_wal_flush(ctx: TaskContext) {
+    pal_emit(DaemonEvent::WalFlushStart);
+    tracing::info!("wal flush task started");
+    ctx.syscall(SystemCall::Sleep(Duration::from_millis(10)));
+    pal_emit(DaemonEvent::WalFlushFinish);
+    tracing::info!("wal flush task finished");
+}
+
+/// Loop task responsible for pushing runtime metrics.
+///
+/// Similar to [`looptask_wal_flush`], this task emits PAL events so tests can
+/// verify that it started. Real implementations would collect and export
+/// metrics to a monitoring system.
+#[instrument(skip(ctx))]
+pub fn looptask_metrics(ctx: TaskContext) {
+    pal_emit(DaemonEvent::MetricsStart);
+    tracing::info!("metrics task started");
+    ctx.syscall(SystemCall::Sleep(Duration::from_millis(10)));
+    pal_emit(DaemonEvent::MetricsFinish);
+    tracing::info!("metrics task finished");
+}
 
 /// Initialize the daemon and return a running instance.
 #[instrument(skip(cfg))]
@@ -66,6 +94,10 @@ impl Daemon {
         let _watcher = signal::start_watcher(&self.cfg.config_path).ok();
 
         let mut sched = Scheduler::new();
+        unsafe {
+            sched.spawn_system(looptask_wal_flush);
+            sched.spawn_system(looptask_metrics);
+        }
         run_blocking(&mut sched)?;
 
         pal::emit(DaemonEvent::ShutdownComplete);

--- a/crates/daemon/src/pal.rs
+++ b/crates/daemon/src/pal.rs
@@ -14,6 +14,14 @@ pub enum DaemonEvent {
     ShutdownBegin,
     /// All shutdown work has completed and the daemon is exiting.
     ShutdownComplete,
+    /// The WAL flush task has started.
+    WalFlushStart,
+    /// The WAL flush task finished execution.
+    WalFlushFinish,
+    /// The metrics task has started.
+    MetricsStart,
+    /// The metrics task finished execution.
+    MetricsFinish,
 }
 
 lazy_static! {

--- a/crates/daemon/tests/daemon.rs
+++ b/crates/daemon/tests/daemon.rs
@@ -34,10 +34,28 @@ fn pal_events_logged_on_sigint() {
     raise(SIGINT).unwrap();
     handle.join().unwrap().unwrap();
     let events = take_events();
-    assert_eq!(
-        events,
-        vec![DaemonEvent::ShutdownBegin, DaemonEvent::ShutdownComplete]
-    );
+    assert!(events.contains(&DaemonEvent::WalFlushStart));
+    assert!(events.contains(&DaemonEvent::MetricsStart));
+    assert!(events.contains(&DaemonEvent::ShutdownBegin));
+    assert!(events.contains(&DaemonEvent::ShutdownComplete));
+}
+
+#[test]
+#[serial]
+fn system_tasks_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "").unwrap();
+
+    let cfg = Config::load(&path).unwrap();
+    let daemon = daemon::init(cfg).unwrap();
+    let handle = std::thread::spawn(move || daemon.run());
+    std::thread::sleep(Duration::from_millis(50));
+    raise(SIGTERM).unwrap();
+    handle.join().unwrap().unwrap();
+    let events = take_events();
+    assert!(events.contains(&DaemonEvent::WalFlushStart));
+    assert!(events.contains(&DaemonEvent::MetricsStart));
 }
 
 #[test]

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -14,5 +14,6 @@ pub use pal::{TaskEvent, emit as pal_emit};
 pub use ready_queue::{ReadyEntry, ReadyQueue};
 pub use scheduler::Scheduler;
 pub use syscall::SystemCall;
+pub use task::TaskContext;
 pub use task::{Task, TaskId};
 pub use wait_map::WaitMap;

--- a/crates/scheduler/src/scheduler.rs
+++ b/crates/scheduler/src/scheduler.rs
@@ -19,6 +19,11 @@ use crate::syscall::SystemCall;
 use crate::task::{Task, TaskContext, TaskId, TaskState};
 use crate::wait_map::WaitMap;
 
+/// Priority level reserved for internal system tasks.
+pub const PRI_SYSTEM: u8 = 0;
+/// Default priority assigned to user tasks.
+pub const PRI_DEFAULT: u8 = 10;
+
 /// Core runtime orchestrator managing runnable tasks, pending I/O events,
 /// and join waiters.
 pub struct Scheduler {
@@ -161,7 +166,23 @@ impl Scheduler {
     where
         F: FnOnce(TaskContext) + Send + 'static,
     {
-        unsafe { self.spawn_with_priority(10, f) }
+        unsafe { self.spawn_with_priority(PRI_DEFAULT, f) }
+    }
+
+    /// Spawn a new coroutine task reserved for internal system work.
+    ///
+    /// System tasks use [`PRI_SYSTEM`] to ensure they run before normal
+    /// user tasks. See [`spawn_with_priority`] for details.
+    ///
+    /// # Safety
+    /// This method ultimately delegates to [`may::coroutine::spawn`]. The
+    /// caller must guarantee that the provided closure does not reference
+    /// data which could be invalid once the task begins execution.
+    pub unsafe fn spawn_system<F>(&mut self, f: F) -> TaskId
+    where
+        F: FnOnce(TaskContext) + Send + 'static,
+    {
+        unsafe { self.spawn_with_priority(PRI_SYSTEM, f) }
     }
 
     /// Run the scheduler loop, processing system calls from tasks.


### PR DESCRIPTION
## Summary
- implement `looptask_wal_flush` and `looptask_metrics`
- log PAL events for looptasks
- add scheduler `spawn_system` API and priority constants
- spawn system tasks in `Daemon::run`
- update daemon tests for new events

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_686f5f0310bc832fb5319c618c312d6d