### PR TITLE
Add optional interface features to daemon

### DIFF
--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,9 +13,15 @@ signal-hook = { version = "0.3", features = ["iterator"] }
 crossbeam = "0.8"
 notify = "6"
 tokio = { version = "1", features = ["rt", "sync", "net"] }
-hyper = { version = "0.14", features = ["server"] }
+hyper = { version = "0.14", features = ["server", "tcp", "http1"] }
 scheduler = { path = "../scheduler" }
 lazy_static = "1"
+
+[features]
+default = []
+ipc = []
+grpc = []
+a2a = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/daemon/README.md
+++ b/crates/daemon/README.md
@@ -54,6 +54,24 @@ sequenceDiagram
 * Optional inotify/fsevents config hot-reloading
 * Designed to run inside Firecracker or Apple container environments
 
+### Cargo Feature Flags
+
+The daemon provides several optional interfaces that can be enabled at compile
+time:
+
+| Feature | Description |
+|---------|-------------|
+| `ipc`   | Accept jobs via Unix domain sockets |
+| `grpc`  | Expose a gRPC server for remote control |
+| `a2a`   | Enable asynchronous agent-to-agent messaging |
+
+These features are disabled by default. Build with `--features` to enable one or
+more interfaces:
+
+```bash
+cargo build -p daemon --features ipc,grpc
+```
+
 ---
 
 ## 📦 Project Layout

--- a/crates/daemon/src/a2a.rs
+++ b/crates/daemon/src/a2a.rs
@@ -1,0 +1,25 @@
+//! A2A protocol support for message-based interaction.
+//!
+//! When the `a2a` feature is enabled this module provides a placeholder service
+//! representing asynchronous agent-to-agent communication.
+
+use tracing::instrument;
+
+/// Handle to the running A2A service.
+#[derive(Debug)]
+pub struct A2aService;
+
+impl A2aService {
+    /// Start the A2A service.
+    #[instrument]
+    pub fn start() -> Self {
+        tracing::info!("a2a service started");
+        Self
+    }
+
+    /// Shut down the A2A service.
+    #[instrument]
+    pub fn shutdown(self) {
+        tracing::info!("a2a service stopped");
+    }
+}

--- a/crates/daemon/src/grpc.rs
+++ b/crates/daemon/src/grpc.rs
@@ -1,0 +1,26 @@
+//! gRPC interface for remote daemon control.
+//!
+//! This module is compiled only when the `grpc` feature is enabled. It exposes a
+//! stub service that demonstrates how a real gRPC server could be wired into the
+//! daemon.
+
+use tracing::instrument;
+
+/// Handle to the running gRPC service.
+#[derive(Debug)]
+pub struct GrpcService;
+
+impl GrpcService {
+    /// Start the gRPC service.
+    #[instrument]
+    pub fn start() -> Self {
+        tracing::info!("grpc service started");
+        Self
+    }
+
+    /// Shut down the gRPC service.
+    #[instrument]
+    pub fn shutdown(self) {
+        tracing::info!("grpc service stopped");
+    }
+}

--- a/crates/daemon/src/ipc.rs
+++ b/crates/daemon/src/ipc.rs
@@ -1,0 +1,26 @@
+//! IPC interface for job submission over Unix sockets.
+//!
+//! This module is compiled only when the `ipc` feature is enabled. It provides a
+//! simple stub service used in tests to ensure the optional interface builds
+//! correctly.
+
+use tracing::instrument;
+
+/// Handle to the running IPC service.
+#[derive(Debug)]
+pub struct IpcService;
+
+impl IpcService {
+    /// Start the IPC service.
+    #[instrument]
+    pub fn start() -> Self {
+        tracing::info!("ipc service started");
+        Self
+    }
+
+    /// Shut down the IPC service.
+    #[instrument]
+    pub fn shutdown(self) {
+        tracing::info!("ipc service stopped");
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,7 +1,13 @@
 //! Daemon runtime entry points.
 
+#[cfg(feature = "a2a")]
+pub mod a2a;
 pub mod config;
+#[cfg(feature = "grpc")]
+pub mod grpc;
 mod http;
+#[cfg(feature = "ipc")]
+pub mod ipc;
 mod pal;
 mod signal;
 
@@ -100,6 +106,13 @@ impl Daemon {
         let addr: SocketAddr = DEFAULT_ADDR.parse().expect("valid addr");
         let http = HttpServer::start(addr)?;
 
+        #[cfg(feature = "ipc")]
+        let ipc = ipc::IpcService::start();
+        #[cfg(feature = "grpc")]
+        let grpc = grpc::GrpcService::start();
+        #[cfg(feature = "a2a")]
+        let a2a = a2a::A2aService::start();
+
         let mut sched = Scheduler::new();
         unsafe {
             sched.spawn_system(looptask_wal_flush);
@@ -108,6 +121,13 @@ impl Daemon {
         run_blocking(&mut sched)?;
 
         http.shutdown();
+
+        #[cfg(feature = "ipc")]
+        ipc.shutdown();
+        #[cfg(feature = "grpc")]
+        grpc.shutdown();
+        #[cfg(feature = "a2a")]
+        a2a.shutdown();
 
         pal::emit(DaemonEvent::ShutdownComplete);
         tracing::info!("daemon shutdown complete");

--- a/crates/daemon/tests/features.rs
+++ b/crates/daemon/tests/features.rs
@@ -1,0 +1,43 @@
+use serial_test::serial;
+use std::process::Command;
+
+fn build_with(features: &[&str]) {
+    let mut cmd = Command::new("cargo");
+    cmd.args(["build", "--package", "daemon"]);
+    if !features.is_empty() {
+        cmd.arg("--features");
+        cmd.arg(features.join(","));
+    }
+    let status = cmd.status().expect("failed to run cargo");
+    assert!(status.success());
+}
+
+#[test]
+#[serial]
+fn build_default() {
+    build_with(&[]);
+}
+
+#[test]
+#[serial]
+fn build_ipc() {
+    build_with(&["ipc"]);
+}
+
+#[test]
+#[serial]
+fn build_grpc() {
+    build_with(&["grpc"]);
+}
+
+#[test]
+#[serial]
+fn build_a2a() {
+    build_with(&["a2a"]);
+}
+
+#[test]
+#[serial]
+fn build_all() {
+    build_with(&["ipc", "grpc", "a2a"]);
+}


### PR DESCRIPTION
## Summary
- add `ipc`, `grpc`, and `a2a` feature flags in daemon
- implement stub modules for each optional interface
- start/stop optional services when enabled
- document available features in the daemon README
- ensure daemon builds with or without each feature via tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_686f71ca00a0832fa5712f29d59edfad