### PR TITLE
Add RUST_LOG support for tinkerbell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "autocfg"
@@ -70,6 +92,17 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.9",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -204,9 +237,11 @@ name = "daemon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "crossbeam",
  "hyper",
  "lazy_static",
+ "nix 0.30.1",
  "notify",
  "reqwest",
  "scheduler",
@@ -234,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +284,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docsbookgen"
@@ -1121,6 +1168,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1847,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wal"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 signal-hook = { version = "0.3", features = ["iterator"] }
 crossbeam = "0.8"
 notify = "6"
@@ -27,3 +27,9 @@ a2a = []
 tempfile = "3"
 serial_test = "2"
 reqwest = { version = "0.11", features = ["blocking"] }
+assert_cmd = "2"
+nix = { version = "0.30", features = ["signal", "process"] }
+
+[[bin]]
+name = "tinkerbell"
+path = "bin/tinkerbell.rs"

--- a/crates/daemon/README.md
+++ b/crates/daemon/README.md
@@ -101,6 +101,19 @@ RUST_LOG=debug cargo run -p daemon
 touch config.toml
 ```
 
+### Log Levels
+
+Set the `RUST_LOG` environment variable to control verbosity. The following
+levels are supported:
+
+| Level | Description |
+|-------|-------------|
+| `trace` | Extremely verbose tracing useful for diagnostics |
+| `debug` | Debug information about internal state |
+| `info`  | High-level operational messages |
+| `warn`  | Something unexpected happened but the daemon can continue |
+| `error` | A failure occurred that may require intervention |
+
 ---
 
 ## 🔌 Integration

--- a/crates/daemon/bin/tinkerbell.rs
+++ b/crates/daemon/bin/tinkerbell.rs
@@ -1,15 +1,21 @@
 use daemon::config::Config;
+use tracing_subscriber::{EnvFilter, fmt};
 
 /// Main entry point for the `tinkerbell` daemon binary.
 ///
 /// This function initializes logging, loads configuration from disk,
 /// and delegates execution to [`daemon::run`].
+#[tracing::instrument]
 fn main() -> anyhow::Result<()> {
-    // Initialize logging
-    tracing_subscriber::fmt::init();
+    // Initialize logging using RUST_LOG if set
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    fmt().with_env_filter(filter).init();
 
     // Load configuration
-    let path = std::env::args().nth(1).unwrap_or_else(|| "config.toml".into());
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "config.toml".into());
+    tracing::debug!(%path, "loading configuration");
     let cfg = Config::load(&path)?;
 
     // Run the daemon

--- a/crates/daemon/tests/logging.rs
+++ b/crates/daemon/tests/logging.rs
@@ -1,0 +1,28 @@
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+use serial_test::serial;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[test]
+#[serial]
+fn debug_logs_emitted() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    std::fs::write(&path, "").unwrap();
+
+    let bin = assert_cmd::cargo::cargo_bin("tinkerbell");
+    let child = Command::new(bin)
+        .arg(&path)
+        .env("RUST_LOG", "debug")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM);
+    let output = child.wait_with_output().unwrap();
+    let logs = String::from_utf8_lossy(&output.stdout);
+    assert!(logs.contains("DEBUG"), "logs missing debug level: {logs}");
+}


### PR DESCRIPTION
## Summary
- enable env-filter support and define `tinkerbell` binary
- configure `tracing_subscriber` in `bin/tinkerbell.rs`
- document log levels in daemon README
- verify debug log emission when `RUST_LOG=debug`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p daemon`

------
https://chatgpt.com/codex/tasks/task_e_686f76f43900832f8b89c98822ab8f40